### PR TITLE
kb popup: Cmd+Alt+Space → kitty quick-access nvim+:KbTodo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
-.PHONY: all zsh kitty nvim tmux claude-code
+.PHONY: all zsh kitty nvim tmux claude-code skhd
 
-all: zsh nvim kitty tmux claude-code
+all: zsh nvim kitty tmux claude-code skhd
 
-kitty nvim tmux claude-code:
+kitty nvim tmux claude-code skhd:
 	stow -t ~ $@
 ifeq ($(shell uname),Darwin)
 	@[ -d macos/$@ ] && stow -d macos -t ~ $@ || true

--- a/install-macos.sh
+++ b/install-macos.sh
@@ -73,6 +73,30 @@ else
     echo "  ✓ TPM already installed"
 fi
 
+
+# kb popup — OS-level hotkey daemon
+if ! brew list skhd >/dev/null 2>&1; then
+  brew tap koekeishiya/formulae
+  brew install skhd
+fi
+skhd --start-service
+
+# Free Cmd+Alt+Space from Spotlight (Show Finder search window)
+# 65 = Spotlight's "Show Finder search window" symbolic hotkey
+defaults write com.apple.symbolichotkeys AppleSymbolicHotKeys -dict-add 65 \
+  '<dict><key>enabled</key><false/></dict>'
+
+cat <<'EOF'
+
+============================================================
+kb popup — manual setup steps remaining:
+  1. Reboot or logout/login (Spotlight unbind takes effect)
+  2. System Settings → Privacy & Security → Accessibility
+     → enable skhd if not already enabled
+  3. Press Cmd+Alt+Space to verify the popup launches
+============================================================
+EOF
+
 echo
 echo "Next steps:"
 echo "  1. Run 'make zsh' to stow zsh configuration"

--- a/kitty/.config/kitty/kb-popup.session
+++ b/kitty/.config/kitty/kb-popup.session
@@ -1,0 +1,1 @@
+launch nvim '+lua vim.cmd("cd "..vim.fn.fnameescape(require("kb.config").vault()))' '+KbTodo'

--- a/kitty/.config/kitty/kitty.conf
+++ b/kitty/.config/kitty/kitty.conf
@@ -19,6 +19,7 @@ macos_colorspace srgb
 
 # Font
 font_family MesloLGS Nerd Font
+font_size 13.0
 
 # Shift+Enter → LF (so it survives tmux and triggers chat:newline in Claude Code)
 map shift+enter send_text all \x0a

--- a/kitty/.config/kitty/quick-access-terminal.conf
+++ b/kitty/.config/kitty/quick-access-terminal.conf
@@ -1,0 +1,6 @@
+# kb popup panel — toggled via skhd → Cmd+Alt+Space
+position center-sized
+width 140
+height 40
+hide_on_focus_loss yes
+startup_session kb-popup.session

--- a/kitty/.config/kitty/quick-access-terminal.conf
+++ b/kitty/.config/kitty/quick-access-terminal.conf
@@ -7,3 +7,4 @@ background_opacity 0.9
 kitty_override startup_session=kb-popup.session
 kitty_override background_blur=64
 kitty_override window_padding_width=10
+kitty_override hide_window_decorations=titlebar-only

--- a/kitty/.config/kitty/quick-access-terminal.conf
+++ b/kitty/.config/kitty/quick-access-terminal.conf
@@ -3,4 +3,7 @@ edge center-sized
 columns 140
 lines 40
 hide_on_focus_loss yes
+background_opacity 0.9
 kitty_override startup_session=kb-popup.session
+kitty_override background_blur=64
+kitty_override window_padding_width=10

--- a/kitty/.config/kitty/quick-access-terminal.conf
+++ b/kitty/.config/kitty/quick-access-terminal.conf
@@ -1,6 +1,6 @@
 # kb popup panel — toggled via skhd → Cmd+Alt+Space
-position center-sized
-width 140
-height 40
+edge center-sized
+columns 140
+lines 40
 hide_on_focus_loss yes
-startup_session kb-popup.session
+kitty_override startup_session=kb-popup.session

--- a/skhd/.config/skhd/skhdrc
+++ b/skhd/.config/skhd/skhdrc
@@ -1,0 +1,2 @@
+# kb popup — toggle quick-access-terminal panel
+cmd + alt - space : /Applications/kitty.app/Contents/MacOS/kitten quick-access-terminal


### PR DESCRIPTION
## Summary

OS-level hotkey popup for editing the kb vault's `todo.md`. Pressing `Cmd+Alt+Space` toggles a centered, semi-transparent kitty panel running `nvim` with the kb todo modal already engaged.

**Architecture:** skhd binds the hotkey → `kitten quick-access-terminal` (built-in kitty panel) → kitty session launches nvim → existing `:KbTodo` opens vault/todo.md → existing `kb.todo_modal` autocmd attaches. No Hammerspoon, no custom daemon.

**New stow packages:**
- `skhd/` — single-rule hotkey daemon config
- `kitty/` (existing) gets two new files: `quick-access-terminal.conf` + `kb-popup.session`

**Tweaks shipped alongside:**
- `kitty.conf` defaults to 13pt (matches typical post-Cmd+Shift+= state, saves the warm-up press)
- Popup panel: 140 cols × 40 rows, centered, opacity 0.9, blur 64, padding 10, hide-on-focus-loss

**Bootstrap:** `install-macos.sh` adds skhd install (with `koekeishiya/formulae` tap), `skhd --start-service`, and a `defaults write` to free Cmd+Alt+Space from Spotlight's Finder search. Manual steps remaining (printed by the script): reboot to apply Spotlight unbind, grant skhd Accessibility permission.

**vault cwd:** popup nvim chdirs to `kb.config.vault()` via inline `+lua` flag — popup-only, doesn't affect regular `:KbTodo` invocations.

## Commits
- `5b64eb6` kitty: add kb-popup session for nvim+:KbTodo with vault cwd
- `b262863` kitty: add quick-access-terminal panel config (140x40 centered)
- `8d1dadd` skhd: add stow package + Makefile target for kb popup hotkey
- `573a787` install-macos: bootstrap skhd + free Cmd+Alt+Space from Spotlight
- `ad77a03` kitty: fix quick-access-terminal.conf option names (edge/columns/lines, kitty_override startup_session)
- `aa057be` kitty: 13pt default font + popup polish (opacity, blur, padding)
- `de4a1fa` kitty: try titlebar-only decorations for popup rounded corners

## Test plan
- [x] On a fresh clone, `./install-macos.sh` runs idempotently and bootstraps skhd
- [x] `make all` (or `make skhd kitty`) stows both packages
- [x] Reboot + grant skhd Accessibility, then Cmd+Alt+Space toggles the popup
- [x] Popup is centered, ~140×40, semi-transparent, with blur underneath, 10px padding
- [x] nvim launches with `:pwd` showing vault root and todo modal active (`?` opens help)
- [x] Hide/show preserves nvim state across hotkey toggles
- [x] Click outside popup hides it (hide_on_focus_loss)
- [x] `:q` ends the session; next hotkey is a fresh spawn
- [x] Regular `:KbTodo` invocation still doesn't chdir to vault (popup-only behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)